### PR TITLE
Support for large memory snapshots improved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,11 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -48,6 +53,27 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
+    },
+    "stream-chain": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.4.tgz",
+      "integrity": "sha512-9lsl3YM53V5N/I1C2uJtc3Kavyi3kNYN83VkKb/bMWRk7D9imiFyUPYa0PoZbLohSVOX1mYE9YsmwObZUsth6Q=="
+    },
+    "stream-json": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.7.1.tgz",
+      "integrity": "sha512-I7g0IDqvdJXbJ279/D3ZoTx0VMhmKnEF7u38CffeWdF8bfpMPsLo+5fWnkNjO2GU/JjWaRjdH+zmH03q+XGXFw==",
+      "requires": {
+        "stream-chain": "^2.2.3"
       }
     },
     "ts-node": {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,9 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "stream": "0.0.2",
+    "stream-json": "^1.7.1"
+  }
 }

--- a/src/cleaner.ts
+++ b/src/cleaner.ts
@@ -1,26 +1,48 @@
 import {GraphManager} from "./graph-manager";
-import {readFileSync, writeFileSync} from 'fs';
-
+import {writeFileSync, createReadStream} from 'fs';
+const StreamObject = require( 'stream-json/streamers/StreamObject');
+const {Writable} = require('stream');
 
 // Reduces the heap snapshot with focus on a node with a given id or if not provided,
 // on a single detached window found in the snapshot.
 const run = async (filePath: string, nodeId: string | undefined) => {
   console.log('reading file - start!');
-  const jsonData = await readFileSync(filePath, 'utf-8');
-  console.log('reading file - end!');
+  let jsonData = {} as any;
+  const fileStream = createReadStream(filePath);
+  const jsonStream = StreamObject.withParser();
+  const processingStream = new Writable({
+    write({key, value}, encoding, callback) {
+      // allows memory cleanup
+      setTimeout(() => {
+        console.log("- read:", key);
+        jsonData[key] = value;
+        callback();
+      }, 0);
+    },
+    objectMode: true
+  });
 
-  const graphManager = new GraphManager(JSON.parse(jsonData));
-  const nodeIdToFocus = nodeId === undefined
+  fileStream.pipe(jsonStream.input);
+  jsonStream.pipe(processingStream);
+
+  processingStream.on('finish', async () => {
+    console.log('reading file - end!');
+
+    const graphManager = new GraphManager(jsonData);
+    const nodeIdToFocus = nodeId === undefined
       ? graphManager.findNodeByName('Detached Window').getNodeId()
       : parseInt(nodeId);
-  graphManager.focusOnNode(nodeIdToFocus,
+
+    console.log("NodeID: ", nodeIdToFocus);
+
+    graphManager.focusOnNode(nodeIdToFocus,
       graphManager.findNodeByName('(GC roots)').getNodeId());
-  const jsonOutput = graphManager.exportGraphToJson();
-  await writeFileSync('./output.heapsnapshot', jsonOutput, {encoding: 'utf-8'});
-  console.log("See output in output.heapsnapshot");
+    const jsonOutput = graphManager.exportGraphToJson();
+    await writeFileSync('./output.heapsnapshot', jsonOutput, {encoding: 'utf-8'});
+    console.log("See output in output.heapsnapshot");
+  });
 };
 
-console.log(process.argv.slice(2));
 const appParams = process.argv.slice(2);
 run(/* filePath */ appParams[0], /* nodeId */ appParams[1]).then();
 


### PR DESCRIPTION
When running the heap-cleaner on large memory snapshots, it runs into several issues which this PR addresses:
 1. Unable to load large file- solved by using streams instead of sync read file
 2. Unable to parse large JSON - solved by stream json decode
 3. Breaking number of arguments limits when destructing params - solved by not using `...` operator and instead loop over with `for`
 4. Collecting retainers was using recursive approach which lead to app crashing on large snapshots, optimized it to use iterative approach which doesn't crash for large files

Please note that using stream to read file and decode JSON is a bit slower than before, but it mitigates the issue of not being able to read larger files at all so IMO it's acceptable trade-off.

For memory snapshots >= 1GB even with streams we run into issues with max array size and am looking into if we can resolve that one also in the `stream-json `package.