### PR TITLE
Output for multiple nodes

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,7 +5,7 @@
   "semi": false,
   "singleQuote": true,
   "jsxSingleQuote": false,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "bracketSpacing": true,
   "printWidth": 120,
   "quoteProps": "consistent",

--- a/README.md
+++ b/README.md
@@ -6,5 +6,13 @@ Just run src/bin.ts with the input file and optionally pass in a node id to focu
 If the node to focus is not provided, the program will try to find a detached window and focus on it.
 
 ```
-node --require ts-node/register --max-old-space-size=32768 --stack-size=320000000 src/bin.ts sample/sample.heapsnapshot
+node --require ts-node/register --max-old-space-size=32768 src/bin.ts sample/sample.heapsnapshot
 ```
+
+or
+
+```
+npx heap-cleaner sample/sample.heapsnapshot
+```
+
+without need to clone the repo, but you will not be able to extend memory for big heap snapshots.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "start": "node --require ts-node/register --max-old-space-size=32768 --stack-size=320000000 src/bin.ts",
+    "start": "node --require ts-node/register --max-old-space-size=32768 src/bin.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|jsx|ts|tsx|json)\"",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,6 +3,6 @@ import { log, error } from './log'
 import { run } from './index'
 
 const appParams = process.argv.slice(2)
-run(/* filePath */ appParams[0], /* nodeId */ appParams[1])
+run(/* filePath */ appParams[0], /* nodeId */ appParams.slice(1))
   .then(() => log('done'))
   .catch((err) => error(err))

--- a/src/graph-manager.ts
+++ b/src/graph-manager.ts
@@ -32,12 +32,12 @@ export class GraphManager {
     this.edgeWeakType = snapshot.edgeWeakType
 
     this.jsonHeapDump = {
-      snapshot: snapshot.profile.snapshot,
+      snapshot: { ...snapshot.profile.snapshot },
       nodes: [],
       edges: [],
       samples: [],
       locations: [],
-      strings: snapshot.profile.strings,
+      strings: [...snapshot.profile.strings],
     }
     this.constructGraph(snapshot)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,30 @@ import { extname } from 'path'
 import { GraphManager } from './graph-manager'
 import { type HeapSnapshotWorkerDispatcher } from './vendor/HeapSnapshotWorkerDispatcher'
 import { HeapSnapshotLoader } from './vendor/HeapSnapshotLoader'
-import { log } from './log'
+import { error, log } from './log'
 import { JSHeapSnapshot } from './vendor/HeapSnapshot'
+
+const printMessage = ({ string, values }: { string: string; values: Record<string, string> }) =>
+  Object.keys(values).reduce((acc, key) => acc.replace(`{${key}}`, values[key]), string)
 
 export const loadSnapshot = async (filePath: string) => {
   const readStream = createReadStream(filePath, {
     highWaterMark: 10 * 1024 * 1024,
     encoding: 'utf8',
   })
+  const logStream: NodeJS.WriteStream = process.stdout
   const dispatcher = {
-    sendEvent: (...args: any[]) => log('HeapSnapshotWorkerDispatcher.sendEvent', ...args),
+    sendEvent: (...args: any[]) => {
+      logStream.clearLine(0)
+      logStream.cursorTo(0)
+      logStream.write(
+        [
+          new Date().toISOString(),
+          'HeapSnapshotWorkerDispatcher',
+          ...(args[0] === 'ProgressUpdate' ? printMessage(JSON.parse(args[1])) : args),
+        ].join(' ')
+      )
+    },
     dispatchMessage: (...args: any[]) => log('HeapSnapshotWorkerDispatcher.dispatchMessage', ...args),
   } as unknown as HeapSnapshotWorkerDispatcher
   const loader = new HeapSnapshotLoader(dispatcher)
@@ -29,13 +43,13 @@ export const loadSnapshot = async (filePath: string) => {
   })
 
   await loaderPromise
-  return loader.buildSnapshot()
+  const snapshot = loader.buildSnapshot()
+  logStream.write('\n')
+  return snapshot
 }
 
-export const focusOnNode = (snapshot: JSHeapSnapshot, nodeId: string | undefined) => {
+export const focusOnNode = (snapshot: JSHeapSnapshot, nodeIdToFocus: number) => {
   const graphManager = new GraphManager(snapshot)
-  const nodeIdToFocus =
-    nodeId === undefined ? graphManager.findNodeByName('Detached Window').getNodeId() : parseInt(nodeId)
   graphManager.focusOnNode(nodeIdToFocus, graphManager.findNodeByName('(GC roots)').getNodeId())
   const jsonOutput = graphManager.exportGraphToJson()
   return { jsonOutput, nodeIdToFocus }
@@ -43,19 +57,38 @@ export const focusOnNode = (snapshot: JSHeapSnapshot, nodeId: string | undefined
 
 // Reduces the heap snapshot with focus on a node with a given id or if not provided,
 // on a single detached window found in the snapshot.
-export const run = async (filePath: string, nodeId: string | undefined) => {
+export const run = async (filePath: string, nodeIds: string[]) => {
   log(`reading file ${filePath} - start!`)
   const snapshot = await loadSnapshot(filePath)
   log('reading file - end!')
 
-  if (nodeId === undefined) {
-    log('Looking for detached window')
+  const nodeIdsToFocus: number[] = []
+  if (nodeIds.length === 0) {
+    log('Looking for detached windows')
+    const nodeIterator = snapshot.allNodes()
+    for (const node = nodeIterator.item(); nodeIterator.hasNext(); nodeIterator.next()) {
+      if (node.name() === 'Detached Window') {
+        nodeIdsToFocus.push(node.id())
+      }
+    }
   } else {
-    log('Focusing on node', nodeId)
+    log('Nodes to focus provided')
+    nodeIds.forEach((nodeId) => nodeIdsToFocus.push(parseInt(nodeId)))
   }
-  const { jsonOutput, nodeIdToFocus } = focusOnNode(snapshot, nodeId)
+  log('Focusing on nodes', nodeIdsToFocus.join(', '))
 
-  const output = `${filePath.substring(0, filePath.length - extname(filePath).length)}-${nodeIdToFocus}.heapsnapshot`
-  await fs.writeFile(output, JSON.stringify(jsonOutput), { encoding: 'utf-8' })
-  log(`See output in ${output}`)
+  for (const nodeId of nodeIdsToFocus) {
+    try {
+      const { jsonOutput, nodeIdToFocus } = focusOnNode(snapshot, nodeId)
+
+      const output = `${filePath.substring(
+        0,
+        filePath.length - extname(filePath).length
+      )}-${nodeIdToFocus}.heapsnapshot`
+      await fs.writeFile(output, JSON.stringify(jsonOutput), { encoding: 'utf-8' })
+      log(`See output in ${output}`)
+    } catch (err) {
+      error(`Focusing on node ${nodeId} failed: ${(err as Error).message}`)
+    }
+  }
 }

--- a/src/vendor/HeapSnapshot.ts
+++ b/src/vendor/HeapSnapshot.ts
@@ -867,7 +867,7 @@ export abstract class HeapSnapshot {
   abstract createEdge(_edgeIndex: number): JSHeapSnapshotEdge
   abstract createRetainingEdge(_retainerIndex: number): JSHeapSnapshotRetainerEdge
 
-  private allNodes(): HeapSnapshotNodeIterator {
+  public allNodes(): HeapSnapshotNodeIterator {
     return new HeapSnapshotNodeIterator(this.rootNode())
   }
 


### PR DESCRIPTION
If there are more detached windows, read heap snapshot once and create separate snapshots.
Output file with same name and location as input, with added node id (e.g. sample-1234.heapsnapshot)